### PR TITLE
fix order of arguments to setObject: forKey:

### DIFF
--- a/userdefaults3.py
+++ b/userdefaults3.py
@@ -271,7 +271,7 @@ class ObjCUserDefaults(BaseUserDefaults):
         return self.objcclass.objectForKey_(key)
 
     def __setitem__(self, key, value):
-        self.objcclass.setObject_forKey_(key, at(value))
+        self.objcclass.setObject_forKey_(at(value), key)
 
     def __delitem__(self, key):
         self.objcclass.removeObjectForKey_(key)


### PR DESCRIPTION
transpose the order of arguments to `setObject: forKey:`, which were incorrectly ordered in the original implementation, causing the value to be used as the key, and vice versa.